### PR TITLE
[CAFE-2623] Pop url with IOS exception.

### DIFF
--- a/openidconnect/lib/openidconnect.dart
+++ b/openidconnect/lib/openidconnect.dart
@@ -82,7 +82,7 @@ class OpenIdConnect {
     Function? cookiesCallback,
     bool registration = false,
   }) async {
-    late String? responseUrl;
+    String? responseUrl;
 
     final authEndpoint = Uri.parse(registration
         ? request.configuration.authorizationRegistrationEndpoint ?? request.configuration.authorizationEndpoint

--- a/openidconnect/pubspec.yaml
+++ b/openidconnect/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openidconnect
 description: OpenIdConnect library for flutter.
-version: 1.0.27
+version: 1.0.28
 homepage: https://github.com/4D-Technologies/openidconnect_flutter
 
 environment:


### PR DESCRIPTION
## What's changed in this PR
On IOS there's a bug where `onPageFinished` is not called at specific points during the OAUTH flow. For this reason the `onNavigationRequest` was used for iOS to close the webview but in certain scenarios `onPageFinished` is called causing errors when `onNavigationRequest` is called after that, this only happens on iOS not on Android.

## Testing

### iOS

https://github.com/4D-Technologies/openidconnect_flutter/assets/2182638/5d87ca9f-12ea-4c1c-b339-e85032fb9e69

### Android

https://github.com/4D-Technologies/openidconnect_flutter/assets/2182638/d150e271-7a4c-4c61-ba23-eca661413679

### Testing

1. This only needs to be tested on mobile seeing that this change only applies to the `android_ios.dart` file.
