### PR TITLE
DVOP-10113 ensure null values in auth response don't return as "null"

### DIFF
--- a/openidconnect/lib/src/models/responses/authorization_response.dart
+++ b/openidconnect/lib/src/models/responses/authorization_response.dart
@@ -25,9 +25,9 @@ class AuthorizationResponse extends TokenResponse {
     String? state,
   }) =>
       AuthorizationResponse(
-        accessToken: json["access_token"].toString(),
-        tokenType: json["token_type"].toString(),
-        idToken: json["id_token"].toString(),
+        accessToken: (json["access_token"] ?? "").toString(),
+        tokenType: (json["token_type"] ?? "").toString(),
+        idToken: (json["id_token"] ?? "").toString(),
         refreshToken: json["refresh_token"]?.toString(),
         expiresAt: DateTime.now().add(
           Duration(seconds: (json['expires_in'] as int?) ?? 0),


### PR DESCRIPTION
It's possible that a bad response from the IdP will result in a json object that doesn't have the correct keys here. If that is the case the current implementation will have keys of "null" rather than empty strings. Might be better to throw an error, but in usage it looked like we check for empty values so that seemed a simpler option here.